### PR TITLE
fix: Gradle 9.x compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.codehaus.groovy:groovy:3.0.11")
     compileOnly(gradleApi())
     compileOnly(localGroovy())
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0")
@@ -60,13 +59,13 @@ publishing {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/io/izzel/taboolib/gradle/TabooLibMainTask.groovy
+++ b/src/main/groovy/io/izzel/taboolib/gradle/TabooLibMainTask.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapperKt
@@ -40,10 +41,10 @@ class TabooLibMainTask extends DefaultTask {
     @Input
     boolean api;
 
-    @Input
+    @Internal
     Project project
 
-    @Input
+    @Internal
     TabooLibExtension tabooExt
 
     @TaskAction


### PR DESCRIPTION
## Summary
- Update Gradle wrapper from 7.5 to 9.2.0
- Remove explicit `org.codehaus.groovy:groovy:3.0.11` dependency（Gradle 9 bundles Groovy 4，`localGroovy()` suffices）
- Raise Java/Kotlin target from 1.8 to 21（Gradle 9 requires Java 17+）
- Change `@Input` to `@Internal` for `Project` and `TabooLibExtension` in `TabooLibMainTask`（these types are not serializable as Gradle task inputs）

## Test plan
- [x] `./gradlew jar` builds successfully with Gradle 9.2.0
- [x] `./gradlew publishToMavenLocal` publishes successfully
- [x] Applied plugin used in a downstream project（TabooCoreFirstPlugin）with Gradle 9.x, builds and runs correctly