### PR TITLE
feat: 适配 Gradle 9 (fixed)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: temurin
+          java-version: 17
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
       - name: Grant execute permission for gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .gradle
 .idea
+.kotlin
+bin
 build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,18 @@
+import org.gradle.api.tasks.compile.GroovyCompile
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
-    `maven-publish`
     id("groovy")
-    id("maven-publish")
+    `maven-publish`
     id("java-gradle-plugin")
-    id("com.gradle.plugin-publish") version "0.12.0"
-    kotlin("jvm") version "1.7.10"
+    id("com.gradle.plugin-publish") version "2.0.0"
+    kotlin("jvm") version "1.9.24" // Keep this for compatibility
 }
 
 group = "io.izzel.taboolib"
-version = "2.0.30"
+version = "2.0.36"
 
 configurations {
     create("embed") {
@@ -22,12 +26,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.codehaus.groovy:groovy:3.0.11")
     compileOnly(gradleApi())
     compileOnly(localGroovy())
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
-    "embed"("org.ow2.asm:asm:9.7")
-    "embed"("org.ow2.asm:asm-commons:9.7")
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+    "embed"("org.ow2.asm:asm:9.7.1")
+    "embed"("org.ow2.asm:asm-commons:9.7.1")
     "embed"("com.google.code.gson:gson:2.9.0")
     "embed"(kotlin("stdlib"))
 }
@@ -37,19 +40,17 @@ tasks.jar {
     from(configurations.getByName("embed").map { if (it.isDirectory) it else zipTree(it) })
 }
 
-pluginBundle {
-    website = "https://github.com/TabooLib/taboolib-gradle-plugin"
-    vcsUrl = "https://github.com/TabooLib/taboolib-gradle-plugin"
-    tags = listOf("taboolib", "bukkit", "minecraft")
-}
-
 gradlePlugin {
+    website.set("https://github.com/TabooLib/taboolib-gradle-plugin")
+    vcsUrl.set("https://github.com/TabooLib/taboolib-gradle-plugin")
+
     plugins {
         create("taboolib") {
             id = "io.izzel.taboolib"
             displayName = "TabooLib Gradle Plugin"
             description = "TabooLib Gradle Plugin"
             implementationClass = "io.izzel.taboolib.gradle.TabooLibPlugin"
+            tags.set(listOf("taboolib", "bukkit", "minecraft"))
         }
     }
 }
@@ -60,15 +61,15 @@ publishing {
     }
 }
 
-tasks.compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-tasks.compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.add("-Xskip-metadata-version-check")
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/io/izzel/taboolib/gradle/TabooLibMainTask.groovy
+++ b/src/main/groovy/io/izzel/taboolib/gradle/TabooLibMainTask.groovy
@@ -5,10 +5,14 @@ import io.izzel.taboolib.gradle.description.Builder
 import io.izzel.taboolib.gradle.description.Platforms
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapperKt
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
@@ -23,9 +27,11 @@ import java.util.jar.JarOutputStream
 import java.util.zip.ZipException
 
 @ToString
+@DisableCachingByDefault(because = "Relocates and rewrites jar contents with runtime-dependent metadata.")
 class TabooLibMainTask extends DefaultTask {
 
     @InputFile
+    @PathSensitive(PathSensitivity.NAME_ONLY)
     File inJar
 
     @Input
@@ -38,10 +44,10 @@ class TabooLibMainTask extends DefaultTask {
     @Input
     boolean api;
 
-    @Input
+    @Internal
     Project project
 
-    @Input
+    @Internal
     TabooLibExtension tabooExt
 
     @TaskAction

--- a/src/main/groovy/io/izzel/taboolib/gradle/TabooLibPlugin.groovy
+++ b/src/main/groovy/io/izzel/taboolib/gradle/TabooLibPlugin.groovy
@@ -50,7 +50,7 @@ class TabooLibPlugin implements Plugin<Project> {
             def api = false
             try {
                 project.tasks.taboolibBuildApi.dependsOn(project.tasks.build)
-                api = project.gradle.startParameter.taskRequests.args[0][0].toString() == "taboolibBuildApi"
+                api = project.gradle.startParameter.taskNames.any { it == "taboolibBuildApi" }
             } catch (Throwable ignored) {
             }
 
@@ -78,8 +78,9 @@ class TabooLibPlugin implements Plugin<Project> {
                 }
             }
 
-            project.tasks.jar.finalizedBy(tabooTask)
-            project.tasks.jar.configure { Jar task ->
+            def jarTaskProvider = project.tasks.named('jar', Jar)
+            jarTaskProvider.configure { Jar task ->
+                task.finalizedBy(tabooTask)
                 task.from(taboo.collect { // 在这里打包 "taboo" 依赖
                     if (it.isDirectory()) {
                         it
@@ -96,11 +97,10 @@ class TabooLibPlugin implements Plugin<Project> {
             }
 
             def kotlinVersion = KotlinPluginWrapperKt.getKotlinPluginVersion(project).replaceAll("[._-]", "")
-            def jarTask = project.tasks.jar as Jar
             tabooTask.configure { TabooLibMainTask task ->
                 task.tabooExt = tabooExt
                 task.project = project
-                task.inJar = task.inJar ?: jarTask.archivePath
+                task.inJar = task.inJar ?: jarTaskProvider.get().archiveFile.get().asFile
                 task.relocations = tabooExt.relocation
                 task.classifier = tabooExt.classifier
                 task.api = api

--- a/src/main/kotlin/io/izzel/taboolib/gradle/PrepareMinecraftServerEnvTask.kt
+++ b/src/main/kotlin/io/izzel/taboolib/gradle/PrepareMinecraftServerEnvTask.kt
@@ -5,8 +5,10 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.*
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.*
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
+@DisableCachingByDefault(because = "Downloads remote server artifacts and writes runtime files.")
 abstract class PrepareMinecraftServerEnvTask : DefaultTask() {
 
     init {
@@ -25,8 +27,7 @@ abstract class PrepareMinecraftServerEnvTask : DefaultTask() {
     private val jarNameOrDefault
         get() = jarName.orElse("server.jar")
 
-    @get:Input
-    @get:Optional
+    @get:OutputDirectory
     @get:Option(option = "serverDirectory", description = "For storing server data.")
     abstract val serverDirectory: DirectoryProperty
 


### PR DESCRIPTION
  ## 变更概述

  本次 PR 将插件构建链路升级到 Gradle 9，并修复了 Gradle 9 下自定义任务的插件校验失败问题。

  ## 主要改动

  - Gradle Wrapper 升级到 9.4.0。
  - CI 工作流升级到 Gradle 9 所需运行环境：
      - actions/checkout@v4
      - actions/setup-java@v4
      - distribution: temurin
      - java-version: 17
  - 构建与依赖对齐（面向 Gradle 9）：
      - 清理与旧 Groovy 路径相关的潜在冲突。
      - 保持 Kotlin 工具链/构建配置与当前工程行为一致。
  - 修复 validatePlugins 报错：
      - 为自定义任务类添加 @DisableCachingByDefault。
      - 修正 PrepareMinecraftServerEnvTask 中 DirectoryProperty 的注解使用。
      - 为 TabooLibMainTask 的 @InputFile 增加 @PathSensitive 归一化策略。
      - 将不适合作为输入跟踪的运行时对象（Project、扩展对象）标记为 @Internal。

  ## 变更原因

  Gradle 9 对插件任务属性校验更严格，同时对运行时环境有更明确要求。若不适配，会在 validatePlugins 阶段失败，并在使用侧出
  现类路径冲突风险。

  ## 兼容性说明

  - 构建运行时：JDK 17（满足 Gradle 9 运行要求）
  - 产物目标：仍保持 Java 8 字节码目标，不影响插件使用侧最低运行目标。

  ## 验证情况

  - Gradle7.2，Kotlin1.9.24测试通过
  - Gradle7.2，Kotlin1.8.0测试通过
  - Gradle 9.4.0, Kotlin 2.3.0 测试通过

## 说明

closes #39
closes #38